### PR TITLE
Blockly javascript support

### DIFF
--- a/generators/javascript.js
+++ b/generators/javascript.js
@@ -48,6 +48,7 @@ Blockly.JavaScript.addReservedWords(
     'break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,' +
     'class,enum,export,extends,import,super,implements,interface,let,package,private,protected,public,static,yield,' +
     'const,null,true,false,' +
+    'await,of,arguments,' +
     // https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects
     'Array,ArrayBuffer,Boolean,Date,decodeURI,decodeURIComponent,encodeURI,encodeURIComponent,Error,eval,EvalError,Float32Array,Float64Array,Function,Infinity,Int16Array,Int32Array,Int8Array,isFinite,isNaN,Iterator,JSON,Math,NaN,Number,Object,parseFloat,parseInt,RangeError,ReferenceError,RegExp,StopIteration,String,SyntaxError,TypeError,Uint16Array,Uint32Array,Uint8Array,Uint8ClampedArray,undefined,uneval,URIError,' +
     // https://developer.mozilla.org/en/DOM/window
@@ -160,7 +161,7 @@ Blockly.JavaScript.init = function(workspace) {
           Blockly.Variables.NAME_TYPE);
     }
     Blockly.JavaScript.definitions_['variables'] =
-        'var ' + defvars.join(', ') + ';';
+        'let ' + defvars.join(', ') + ';';
   }
 };
 

--- a/generators/javascript/colour.js
+++ b/generators/javascript/colour.js
@@ -40,7 +40,7 @@ Blockly.JavaScript['colour_random'] = function(block) {
   var functionName = Blockly.JavaScript.provideFunction_(
       'colourRandom',
       ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ + '() {',
-        '  var num = Math.floor(Math.random() * Math.pow(2, 24));',
+        '  let num = Math.floor(Math.random() * Math.pow(2, 24));',
         '  return \'#\' + (\'00000\' + num.toString(16)).substr(-6);',
         '}']);
   var code = functionName + '()';
@@ -84,15 +84,15 @@ Blockly.JavaScript['colour_blend'] = function(block) {
       ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
           '(c1, c2, ratio) {',
        '  ratio = Math.max(Math.min(Number(ratio), 1), 0);',
-       '  var r1 = parseInt(c1.substring(1, 3), 16);',
-       '  var g1 = parseInt(c1.substring(3, 5), 16);',
-       '  var b1 = parseInt(c1.substring(5, 7), 16);',
-       '  var r2 = parseInt(c2.substring(1, 3), 16);',
-       '  var g2 = parseInt(c2.substring(3, 5), 16);',
-       '  var b2 = parseInt(c2.substring(5, 7), 16);',
-       '  var r = Math.round(r1 * (1 - ratio) + r2 * ratio);',
-       '  var g = Math.round(g1 * (1 - ratio) + g2 * ratio);',
-       '  var b = Math.round(b1 * (1 - ratio) + b2 * ratio);',
+       '  let r1 = parseInt(c1.substring(1, 3), 16);',
+       '  let g1 = parseInt(c1.substring(3, 5), 16);',
+       '  let b1 = parseInt(c1.substring(5, 7), 16);',
+       '  let r2 = parseInt(c2.substring(1, 3), 16);',
+       '  let g2 = parseInt(c2.substring(3, 5), 16);',
+       '  let b2 = parseInt(c2.substring(5, 7), 16);',
+       '  let r = Math.round(r1 * (1 - ratio) + r2 * ratio);',
+       '  let g = Math.round(g1 * (1 - ratio) + g2 * ratio);',
+       '  let b = Math.round(b1 * (1 - ratio) + b2 * ratio);',
        '  r = (\'0\' + (r || 0).toString(16)).slice(-2);',
        '  g = (\'0\' + (g || 0).toString(16)).slice(-2);',
        '  b = (\'0\' + (b || 0).toString(16)).slice(-2);',

--- a/generators/javascript/lists.js
+++ b/generators/javascript/lists.js
@@ -51,7 +51,7 @@ Blockly.JavaScript['lists_repeat'] = function(block) {
       'listsRepeat',
       ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
           '(value, n) {',
-       '  var array = [];',
+       '  let array = [];',
        '  for (var i = 0; i < n; i++) {',
        '    array[i] = value;',
        '  }',
@@ -155,7 +155,7 @@ Blockly.JavaScript['lists_getIndex'] = function(block) {
           'listsGetRandomItem',
           ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
               '(list, remove) {',
-           '  var x = Math.floor(Math.random() * list.length);',
+           '  let x = Math.floor(Math.random() * list.length);',
            '  if (remove) {',
            '    return list.splice(x, 1)[0];',
            '  } else {',
@@ -190,7 +190,7 @@ Blockly.JavaScript['lists_setIndex'] = function(block) {
     }
     var listVar = Blockly.JavaScript.variableDB_.getDistinctName(
         'tmpList', Blockly.Variables.NAME_TYPE);
-    var code = 'var ' + listVar + ' = ' + list + ';\n';
+    var code = 'let ' + listVar + ' = ' + list + ';\n';
     list = listVar;
     return code;
   }
@@ -236,7 +236,7 @@ Blockly.JavaScript['lists_setIndex'] = function(block) {
       var code = cacheList();
       var xVar = Blockly.JavaScript.variableDB_.getDistinctName(
           'tmpX', Blockly.Variables.NAME_TYPE);
-      code += 'var ' + xVar + ' = Math.floor(Math.random() * ' + list +
+      code += 'let ' + xVar + ' = Math.floor(Math.random() * ' + list +
           '.length);\n';
       if (mode == 'SET') {
         code += list + '[' + xVar + '] = ' + value + ';\n';
@@ -328,8 +328,8 @@ Blockly.JavaScript['lists_getSublist'] = function(block) {
             ((where1 == 'FROM_END' || where1 == 'FROM_START') ? ', at1' : '') +
             ((where2 == 'FROM_END' || where2 == 'FROM_START') ? ', at2' : '') +
             ') {',
-          '  var start = ' + getIndex_('sequence', where1, 'at1') + ';',
-          '  var end = ' + getIndex_('sequence', where2, 'at2') + ' + 1;',
+          '  let start = ' + getIndex_('sequence', where1, 'at1') + ';',
+          '  let end = ' + getIndex_('sequence', where2, 'at2') + ' + 1;',
           '  return sequence.slice(start, end);',
           '}']);
     var code = functionName + '(' + list +
@@ -352,7 +352,7 @@ Blockly.JavaScript['lists_sort'] = function(block) {
       'listsGetSortCompare',
       ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
           '(type, direction) {',
-       '  var compareFuncs = {',
+       '  let compareFuncs = {',
        '    "NUMERIC": function(a, b) {',
        '        return parseFloat(a) - parseFloat(b); },',
        '    "TEXT": function(a, b) {',
@@ -361,7 +361,7 @@ Blockly.JavaScript['lists_sort'] = function(block) {
        '        return a.toString().toLowerCase() > ' +
           'b.toString().toLowerCase() ? 1 : -1; },',
        '  };',
-       '  var compare = compareFuncs[type];',
+       '  let compare = compareFuncs[type];',
        '  return function(a, b) { return compare(a, b) * direction; }',
        '}']);
   return [list + '.slice().sort(' +

--- a/generators/javascript/loops.js
+++ b/generators/javascript/loops.js
@@ -140,26 +140,14 @@ Blockly.JavaScript['controls_for'] = function(block) {
 };
 
 Blockly.JavaScript['controls_forEach'] = function(block) {
-  // For each loop.
+  // For each loop -- implemented as a for..of es6 loop.
   var variable0 = Blockly.JavaScript.variableDB_.getName(
       block.getFieldValue('VAR'), Blockly.Variables.NAME_TYPE);
   var argument0 = Blockly.JavaScript.valueToCode(block, 'LIST',
       Blockly.JavaScript.ORDER_ASSIGNMENT) || '[]';
   var branch = Blockly.JavaScript.statementToCode(block, 'DO');
   branch = Blockly.JavaScript.addLoopTrap(branch, block.id);
-  var code = '';
-  // Cache non-trivial values to variables to prevent repeated look-ups.
-  var listVar = argument0;
-  if (!argument0.match(/^\w+$/)) {
-    listVar = Blockly.JavaScript.variableDB_.getDistinctName(
-        variable0 + '_list', Blockly.Variables.NAME_TYPE);
-    code += 'var ' + listVar + ' = ' + argument0 + ';\n';
-  }
-  var indexVar = Blockly.JavaScript.variableDB_.getDistinctName(
-      variable0 + '_index', Blockly.Variables.NAME_TYPE);
-  branch = Blockly.JavaScript.INDENT + variable0 + ' = ' +
-      listVar + '[' + indexVar + '];\n' + branch;
-  code += 'for (var ' + indexVar + ' in ' + listVar + ') {\n' + branch + '}\n';
+  var code = 'for (let ' + variable0 + ' of ' + argument0 + ') {\n' + branch + '}\n';
   return code;
 };
 

--- a/generators/javascript/loops.js
+++ b/generators/javascript/loops.js
@@ -48,7 +48,7 @@ Blockly.JavaScript['controls_repeat_ext'] = function(block) {
   if (!repeats.match(/^\w+$/) && !Blockly.isNumber(repeats)) {
     var endVar = Blockly.JavaScript.variableDB_.getDistinctName(
         'repeat_end', Blockly.Variables.NAME_TYPE);
-    code += 'var ' + endVar + ' = ' + repeats + ';\n';
+    code += 'let ' + endVar + ' = ' + repeats + ';\n';
   }
   code += 'for (var ' + loopVar + ' = 0; ' +
       loopVar + ' < ' + endVar + '; ' +
@@ -108,19 +108,19 @@ Blockly.JavaScript['controls_for'] = function(block) {
     if (!argument0.match(/^\w+$/) && !Blockly.isNumber(argument0)) {
       startVar = Blockly.JavaScript.variableDB_.getDistinctName(
           variable0 + '_start', Blockly.Variables.NAME_TYPE);
-      code += 'var ' + startVar + ' = ' + argument0 + ';\n';
+      code += 'let ' + startVar + ' = ' + argument0 + ';\n';
     }
     var endVar = argument1;
     if (!argument1.match(/^\w+$/) && !Blockly.isNumber(argument1)) {
       var endVar = Blockly.JavaScript.variableDB_.getDistinctName(
           variable0 + '_end', Blockly.Variables.NAME_TYPE);
-      code += 'var ' + endVar + ' = ' + argument1 + ';\n';
+      code += 'let ' + endVar + ' = ' + argument1 + ';\n';
     }
     // Determine loop direction at start, in case one of the bounds
     // changes during loop execution.
     var incVar = Blockly.JavaScript.variableDB_.getDistinctName(
         variable0 + '_inc', Blockly.Variables.NAME_TYPE);
-    code += 'var ' + incVar + ' = ';
+    code += 'let ' + incVar + ' = ';
     if (Blockly.isNumber(increment)) {
       code += Math.abs(increment) + ';\n';
     } else {

--- a/generators/javascript/math.js
+++ b/generators/javascript/math.js
@@ -269,7 +269,7 @@ Blockly.JavaScript['math_on_list'] = function(block) {
           'mathMedian',
           ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
               '(myList) {',
-            '  var localList = myList.filter(function (x) ' +
+            '  let localList = myList.filter(function (x) ' +
               '{return typeof x == \'number\';});',
             '  if (!localList.length) return null;',
             '  localList.sort(function(a, b) {return b - a;});',
@@ -292,13 +292,13 @@ Blockly.JavaScript['math_on_list'] = function(block) {
           'mathModes',
           ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
               '(values) {',
-            '  var modes = [];',
-            '  var counts = [];',
-            '  var maxCount = 0;',
+            '  let modes = [];',
+            '  let counts = [];',
+            '  let maxCount = 0;',
             '  for (var i = 0; i < values.length; i++) {',
-            '    var value = values[i];',
-            '    var found = false;',
-            '    var thisCount;',
+            '    let value = values[i];',
+            '    let found = false;',
+            '    let thisCount;',
             '    for (var j = 0; j < counts.length; j++) {',
             '      if (counts[j][0] === value) {',
             '        thisCount = ++counts[j][1];',
@@ -328,10 +328,10 @@ Blockly.JavaScript['math_on_list'] = function(block) {
           'mathStandardDeviation',
           ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
               '(numbers) {',
-            '  var n = numbers.length;',
+            '  let n = numbers.length;',
             '  if (!n) return null;',
-            '  var mean = numbers.reduce(function(x, y) {return x + y;}) / n;',
-            '  var variance = 0;',
+            '  let mean = numbers.reduce(function(x, y) {return x + y;}) / n;',
+            '  let variance = 0;',
             '  for (var j = 0; j < n; j++) {',
             '    variance += Math.pow(numbers[j] - mean, 2);',
             '  }',
@@ -347,7 +347,7 @@ Blockly.JavaScript['math_on_list'] = function(block) {
           'mathRandomList',
           ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
               '(list) {',
-            '  var x = Math.floor(Math.random() * list.length);',
+            '  let x = Math.floor(Math.random() * list.length);',
             '  return list[x];',
             '}']);
       list = Blockly.JavaScript.valueToCode(block, 'LIST',
@@ -395,7 +395,7 @@ Blockly.JavaScript['math_random_int'] = function(block) {
           '(a, b) {',
        '  if (a > b) {',
        '    // Swap a and b to ensure a is smaller.',
-       '    var c = a;',
+       '    let c = a;',
        '    a = b;',
        '    b = c;',
        '  }',

--- a/generators/javascript/text.js
+++ b/generators/javascript/text.js
@@ -131,7 +131,7 @@ Blockly.JavaScript['text_charAt'] = function(block) {
           'textRandomLetter',
           ['function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ +
               '(text) {',
-           '  var x = Math.floor(Math.random() * text.length);',
+           '  let x = Math.floor(Math.random() * text.length);',
            '  return text[x];',
            '}']);
       var code = functionName + '(' + text + ')';
@@ -219,8 +219,8 @@ Blockly.JavaScript['text_getSubstring'] = function(block) {
         ((where1 == 'FROM_END' || where1 == 'FROM_START') ? ', at1' : '') +
         ((where2 == 'FROM_END' || where2 == 'FROM_START') ? ', at2' : '') +
         ') {',
-          '  var start = ' + getIndex_('sequence', where1, 'at1') + ';',
-          '  var end = ' + getIndex_('sequence', where2, 'at2') + ' + 1;',
+          '  let start = ' + getIndex_('sequence', where1, 'at1') + ';',
+          '  let end = ' + getIndex_('sequence', where2, 'at2') + ' + 1;',
           '  return sequence.slice(start, end);',
           '}']);
     var code = functionName + '(' + text +


### PR DESCRIPTION
This PR allows blockly to generate es6-friendly javascript code, with 'let' instead of 'var' for variables. Also added the `await`, `of` and `arguments` keywords to avoid users creating variables or functions with these reserved words.