### PR TITLE
ACA-78 reduced max menu height

### DIFF
--- a/core/css.js
+++ b/core/css.js
@@ -507,7 +507,7 @@ Blockly.Css.CONTENT = [
     'padding: 0 !important;',
     /* max-height value is same as the constant
      * Blockly.FieldDropdown.MAX_MENU_HEIGHT defined in field_dropdown.js. */
-    'max-height: 300px !important;',
+    'max-height: 80px !important;',
   '}',
 
   /* Override the default Closure URL. */

--- a/core/field_dropdown.js
+++ b/core/field_dropdown.js
@@ -82,7 +82,7 @@ Blockly.FieldDropdown.CHECKMARK_OVERHANG = 25;
  * Maximum height of the dropdown menu,it's also referenced in css.js as
  * part of .blocklyDropdownMenu.
  */
-Blockly.FieldDropdown.MAX_MENU_HEIGHT = 300;
+Blockly.FieldDropdown.MAX_MENU_HEIGHT = 80; // three rows, plus a little to show there's more.
 
 /**
  * Android can't (in 2014) display "▾", so use "▼" instead.


### PR DESCRIPTION
Chrome screenshot:
<img width="1136" alt="Screen Shot 2019-05-20 at 2 33 28 pm" src="https://user-images.githubusercontent.com/723717/57997943-98852080-7b12-11e9-8869-b9d2a6972901.png">

IE screenshot:
![0](https://user-images.githubusercontent.com/723717/57997949-9de26b00-7b12-11e9-9971-bab2f0622658.png)
